### PR TITLE
register a winner when the votes reaches the 'votes to win' threshold

### DIFF
--- a/sites/all/modules/playbox_battles/playbox_battles.module
+++ b/sites/all/modules/playbox_battles/playbox_battles.module
@@ -153,9 +153,37 @@ function playbox_battles_vote($ajax, $nid, $type) {
   $votes = $votes + 1;
   $node = node_load($nid);
   $field = 'field_playbox_' . $type . '_votes';
-  $node->{$field}['und'][0]['value'] = $votes;
-  field_attach_update('node', $node);
-
+  $wrapper = entity_metadata_wrapper('node', $node);
+  $wrapper->{$field}->set($votes);
+  
+  $votes_to_win = $wrapper->field_playbox_votes_to_win->value();
+  
+  if ($votes == $votes_to_win) {
+    // Someone won, somone lost. Store this on the node.
+    $wrapper->field_playbox_battle_completed->set(1);
+    $president = $wrapper->field_playbox_president->value();
+    $robot = $wrapper->field_playbox_robot->value();
+    
+    if ($type == 'president') {
+      // President won.
+      $winner_nid = $president->nid;
+      $loser_nid = $robot->nid;
+    }
+    else {
+      // Robot won.
+      $winner_nid = $robot->nid;
+      $loser_nid = $president->nid;
+    }
+  
+    // Set the battle to complete and set a winner and loser.
+    $wrapper->field_playbox_battle_completed->set(1);
+    $wrapper->field_playbox_winner->set($winner_nid);
+    $wrapper->field_playbox_loser->set($loser_nid);
+  }
+  
+  // Save the battle node with all the changes we made.
+  $wrapper->save();
+  
   // Do some fun stuff to update the user IRL
   if ($is_ajax) {
     $commands = array();


### PR DESCRIPTION
Implementing functionality so that once the 'votes to win' threshold is reached the battle is marked as completed, the winner & loser entity references are set. This was needed before the scores page (#41) was able to show any results.
