### PR TITLE
#40 centering presidents and robots images on mobile devices

### DIFF
--- a/sites/all/themes/playbox_theme/css/tweaks.css
+++ b/sites/all/themes/playbox_theme/css/tweaks.css
@@ -108,6 +108,11 @@ input#edit-title {
   top: -50px;
 }
 
+.view-playbox-presidents .views-field-field-playbox-nickname,
+.view-playbox-robots .views-field-field-playbox-nickname {
+  margin-top: 30px;
+}
+
 /* Media Queries */
 
 @media (min-width: 768px) {
@@ -120,6 +125,13 @@ input#edit-title {
     vertical-align: middle;
   }
   div#site-nav-center {
+    text-align: center;
+  }
+}
+
+@media (max-width: 992px) {
+  .view-playbox-presidents .views-field-field-playbox-portrait,
+  .view-playbox-robots .views-field-field-playbox-portrait {
     text-align: center;
   }
 }


### PR DESCRIPTION
Previously, the images would float left and the nicknames were on top of the images.
