### PR TITLE
settings.local.php configuration override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignore paths that contain user-generated content.
 /sites/*/files
 /sites/*/private
+/sites/default/settings.local.php
 /files/*
 /cache
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Ignore paths that contain user-generated content.
 /sites/*/files
 /sites/*/private
-/sites/default/settings.local.php
+/sites/default/local.settings.php
 /files/*
 /cache
 

--- a/sites/default/default.local.settings.php
+++ b/sites/default/default.local.settings.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * Copy this file to local.settings.php in order to override configuration within settings.php
+ * local.settings.php is ignored by git and not deployed to Pantheon
+ */
+ $databases['default']['default'] = array(
+	'driver' => 'mysql',
+	'database' => 'kalamuna_playbox',
+	'username' => 'root',
+	'password' => 'root',
+	'host' => 'localhost',
+  'port' => '8889',
+	'prefix' => '',
+);
+
+$update_free_access = TRUE;
+
+
+$base_url = 'http://'.$_SERVER['HTTP_HOST'].'/kalamuna/playbox'; // NO trailing slash!
+$cookie_domain = $_SERVER['HTTP_HOST'];
+
+#disables Drupal Caching if desired
+/*$conf = array(
+	'cache' => '0',
+	'preprocess_css' => '0',
+	'preprocess_js' => '0',
+	'block_cache' => '0',
+	'page_compression' => '0',
+);*/
+
+ini_set('memory_limit', '500M');
+ini_set('max_execution_time', 300);

--- a/sites/default/settings.php
+++ b/sites/default/settings.php
@@ -591,3 +591,11 @@ if (isset($_SERVER['KALABOX']) &&  $_SERVER['KALABOX'] === 'on') {
   $conf['css_gzip_compression'] = FALSE;  
   $conf['js_gzip_compression'] = FALSE;  
 }
+
+/**
+ * Include a local settings file if it exists.
+ */
+$local_settings = dirname(__FILE__) . '/settings.local.php';
+if (file_exists($local_settings)) {
+  include $local_settings;
+}

--- a/sites/default/settings.php
+++ b/sites/default/settings.php
@@ -595,7 +595,7 @@ if (isset($_SERVER['KALABOX']) &&  $_SERVER['KALABOX'] === 'on') {
 /**
  * Include a local settings file if it exists.
  */
-$local_settings = dirname(__FILE__) . '/settings.local.php';
+$local_settings = dirname(__FILE__) . '/local.settings.php';
 if (file_exists($local_settings)) {
   include $local_settings;
 }


### PR DESCRIPTION
I'd like to enable support for overriding settings.php with a settings.local.php on boxes.  This type of overriding is something I've always liked for enabling a non-version-controlled file to hold database and other configuration changes for local environments. 

You can see a longer discussion on this feature here: https://www.drupal.org/node/1118520.  Alternatively if you have a preferred alternative to this solution for local configuration I could use that.