### PR TITLE
recreated playbox_battles feature

### DIFF
--- a/sites/all/modules/playbox_battles/playbox_battles.info
+++ b/sites/all/modules/playbox_battles/playbox_battles.info
@@ -63,4 +63,4 @@ features[variable][] = panelizer_defaults_node_playbox_battle
 features[variable][] = pathauto_node_playbox_battle_pattern
 features[variable][] = save_continue_playbox_battle
 features[views_view][] = playbox_battles
-mtime = 1435074004
+mtime = 1482111122

--- a/sites/all/modules/playbox_battles/playbox_battles.pages_default.inc
+++ b/sites/all/modules/playbox_battles/playbox_battles.pages_default.inc
@@ -114,7 +114,10 @@ function playbox_battles_default_page_manager_pages() {
       'view_mode' => 'teaser',
     );
     $pane->cache = array();
-    $pane->style = array();
+    $pane->style = array(
+      'settings' => NULL,
+      'style' => 'default',
+    );
     $pane->css = array();
     $pane->extras = array();
     $pane->position = 0;
@@ -159,6 +162,63 @@ function playbox_battles_default_page_manager_pages() {
     $display->content['new-eebd9a2a-5adc-48db-8f12-d27256b638e5'] = $pane;
     $display->panels['row1'][0] = 'new-eebd9a2a-5adc-48db-8f12-d27256b638e5';
     $pane = new stdClass();
+    $pane->pid = 'new-6fb57121-8cb3-4d03-9681-09f65392ce8b';
+    $pane->panel = 'row2';
+    $pane->type = 'views_panes';
+    $pane->subtype = 'playbox_battles-playbox_battles_list_2';
+    $pane->shown = TRUE;
+    $pane->access = array();
+    $pane->configuration = array(
+      'items_per_page' => '10',
+      'fields_override' => array(
+        'field_playbox_battle_completed' => 0,
+        'field_playbox_winner' => 0,
+        'field_playbox_loser' => 0,
+        'title' => 1,
+        'field_playbox_portrait' => 1,
+        'field_playbox_president_votes' => 1,
+        'field_playbox_nickname' => 1,
+        'field_playbox_battle_bio' => 1,
+        'field_playbox_votes_to_win' => 0,
+        'field_playbox_portrait_1' => 1,
+        'field_playbox_robot_votes' => 1,
+        'field_playbox_nickname_1' => 1,
+        'field_playbox_portrait_2' => 0,
+        'field_playbox_nickname_2' => 0,
+      ),
+      'view_settings' => 'table',
+      'header_type' => 'none',
+      'view_mode' => 'teaser',
+    );
+    $pane->cache = array();
+    $pane->style = array(
+      'style' => 'kalacustomize',
+      'settings' => array(
+        'devices' => array(
+          'hidden-xs' => 0,
+          'hidden-sm' => 0,
+          'hidden-md' => 0,
+          'hidden-lg' => 0,
+        ),
+        'pane_style' => array(
+          'clearfix' => 'clearfix',
+          'battler-nickname' => 'battler-nickname',
+          'pull-left' => 0,
+          'pull-right' => 0,
+          'jumbotron' => 0,
+          'well' => 0,
+          'battler-title' => 0,
+        ),
+      ),
+    );
+    $pane->css = array();
+    $pane->extras = array();
+    $pane->position = 0;
+    $pane->locks = array();
+    $pane->uuid = '6fb57121-8cb3-4d03-9681-09f65392ce8b';
+    $display->content['new-6fb57121-8cb3-4d03-9681-09f65392ce8b'] = $pane;
+    $display->panels['row2'][0] = 'new-6fb57121-8cb3-4d03-9681-09f65392ce8b';
+    $pane = new stdClass();
     $pane->pid = 'new-5f94c76c-e8f9-461a-b5cf-9ce9eb3576fd';
     $pane->panel = 'row2';
     $pane->type = 'playbox_static_instructions';
@@ -174,11 +234,11 @@ function playbox_battles_default_page_manager_pages() {
     $pane->style = array();
     $pane->css = array();
     $pane->extras = array();
-    $pane->position = 0;
+    $pane->position = 1;
     $pane->locks = array();
     $pane->uuid = '5f94c76c-e8f9-461a-b5cf-9ce9eb3576fd';
     $display->content['new-5f94c76c-e8f9-461a-b5cf-9ce9eb3576fd'] = $pane;
-    $display->panels['row2'][0] = 'new-5f94c76c-e8f9-461a-b5cf-9ce9eb3576fd';
+    $display->panels['row2'][1] = 'new-5f94c76c-e8f9-461a-b5cf-9ce9eb3576fd';
     $pane = new stdClass();
     $pane->pid = 'new-771a40cd-4cbf-4a8a-9610-0534e8565d4a';
     $pane->panel = 'row4';
@@ -204,7 +264,7 @@ function playbox_battles_default_page_manager_pages() {
   $display->title_pane = '0';
   $handler->conf['display'] = $display;
   $page->default_handlers[$handler->name] = $handler;
-  $pages['playbox_battles'] = $page;
+  $pages[''] = $page;
 
   return $pages;
 

--- a/sites/all/modules/playbox_battles/playbox_battles.strongarm.inc
+++ b/sites/all/modules/playbox_battles/playbox_battles.strongarm.inc
@@ -125,7 +125,7 @@ function playbox_battles_strongarm() {
   $strongarm->api_version = 1;
   $strongarm->name = 'panelizer_defaults_node_playbox_battle';
   $strongarm->value = array(
-    'status' => 0,
+    'status' => 1,
     'view modes' => array(
       'page_manager' => array(
         'status' => 1,
@@ -133,12 +133,12 @@ function playbox_battles_strongarm() {
         'choice' => 0,
       ),
       'default' => array(
-        'status' => 0,
+        'status' => 1,
         'default' => 0,
         'choice' => 0,
       ),
       'teaser' => array(
-        'status' => 0,
+        'status' => 1,
         'default' => 0,
         'choice' => 0,
       ),

--- a/sites/all/modules/playbox_battles/playbox_battles.views_default.inc
+++ b/sites/all/modules/playbox_battles/playbox_battles.views_default.inc
@@ -45,11 +45,6 @@ function playbox_battles_views_default_views() {
   $handler->display->display_options['relationships']['field_playbox_robot_target_id']['table'] = 'field_data_field_playbox_robot';
   $handler->display->display_options['relationships']['field_playbox_robot_target_id']['field'] = 'field_playbox_robot_target_id';
   $handler->display->display_options['relationships']['field_playbox_robot_target_id']['label'] = 'Related Robot';
-  /* Relationship: Entity Reference: Referenced Entity */
-  $handler->display->display_options['relationships']['field_running_mate_target_id']['id'] = 'field_running_mate_target_id';
-  $handler->display->display_options['relationships']['field_running_mate_target_id']['table'] = 'field_data_field_running_mate';
-  $handler->display->display_options['relationships']['field_running_mate_target_id']['field'] = 'field_running_mate_target_id';
-  $handler->display->display_options['relationships']['field_running_mate_target_id']['relationship'] = 'field_playbox_president_target_id';
   /* Field: Content: Battle Completed */
   $handler->display->display_options['fields']['field_playbox_battle_completed']['id'] = 'field_playbox_battle_completed';
   $handler->display->display_options['fields']['field_playbox_battle_completed']['table'] = 'field_data_field_playbox_battle_completed';
@@ -253,7 +248,131 @@ function playbox_battles_views_default_views() {
   $handler = $view->new_display('panel_pane', 'List of completed Playbox Battles', 'playbox_battles_list_2');
   $handler->display->display_options['defaults']['title'] = FALSE;
   $handler->display->display_options['title'] = 'Completed Battles';
+  $handler->display->display_options['defaults']['css_class'] = FALSE;
+  $handler->display->display_options['css_class'] = 'completed-battles';
   $handler->display->display_options['display_description'] = 'A nice list of the completed playbox battles';
+  $handler->display->display_options['defaults']['style_plugin'] = FALSE;
+  $handler->display->display_options['style_plugin'] = 'table';
+  $handler->display->display_options['style_options']['columns'] = array(
+    'field_playbox_battle_completed' => 'field_playbox_battle_completed',
+    'field_playbox_winner' => 'field_playbox_winner',
+    'field_playbox_loser' => 'field_playbox_loser',
+    'title' => 'title',
+    'field_playbox_portrait' => 'field_playbox_portrait',
+    'field_playbox_president_votes' => 'field_playbox_president_votes',
+    'field_playbox_nickname' => 'field_playbox_nickname',
+    'field_playbox_battle_bio' => 'field_playbox_battle_bio',
+    'field_playbox_votes_to_win' => 'field_playbox_votes_to_win',
+    'field_playbox_portrait_1' => 'field_playbox_portrait_1',
+    'field_playbox_robot_votes' => 'field_playbox_robot_votes',
+    'field_playbox_nickname_1' => 'field_playbox_nickname_1',
+    'field_playbox_portrait_2' => 'field_playbox_portrait_2',
+    'field_playbox_nickname_2' => 'field_playbox_nickname_2',
+  );
+  $handler->display->display_options['style_options']['default'] = '-1';
+  $handler->display->display_options['style_options']['info'] = array(
+    'field_playbox_battle_completed' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'field_playbox_winner' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'field_playbox_loser' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'title' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'field_playbox_portrait' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'field_playbox_president_votes' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'field_playbox_nickname' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'field_playbox_battle_bio' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'field_playbox_votes_to_win' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'field_playbox_portrait_1' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'field_playbox_robot_votes' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'field_playbox_nickname_1' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'field_playbox_portrait_2' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'field_playbox_nickname_2' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+  );
+  $handler->display->display_options['defaults']['style_options'] = FALSE;
+  $handler->display->display_options['defaults']['row_plugin'] = FALSE;
+  $handler->display->display_options['defaults']['row_options'] = FALSE;
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
   /* Filter criterion: Content: Published */
@@ -270,6 +389,7 @@ function playbox_battles_views_default_views() {
   $handler->display->display_options['filters']['type']['value'] = array(
     'playbox_battle' => 'playbox_battle',
   );
+  $handler->display->display_options['filters']['type']['group'] = 1;
   /* Filter criterion: Content: Battle Completed (field_playbox_battle_completed) */
   $handler->display->display_options['filters']['field_playbox_battle_completed_value']['id'] = 'field_playbox_battle_completed_value';
   $handler->display->display_options['filters']['field_playbox_battle_completed_value']['table'] = 'field_data_field_playbox_battle_completed';
@@ -277,6 +397,7 @@ function playbox_battles_views_default_views() {
   $handler->display->display_options['filters']['field_playbox_battle_completed_value']['value'] = array(
     1 => '1',
   );
+  $handler->display->display_options['filters']['field_playbox_battle_completed_value']['group'] = 1;
   $handler->display->display_options['pane_title'] = 'List of Completed Battles';
   $handler->display->display_options['pane_description'] = 'A list of the completed playbox battles';
   $handler->display->display_options['pane_category']['name'] = 'Battles';
@@ -411,7 +532,7 @@ function playbox_battles_views_default_views() {
   $handler->display->display_options['title'] = 'All Battles';
   $handler->display->display_options['defaults']['pager'] = FALSE;
   $handler->display->display_options['pager']['type'] = 'none';
-  $handler->display->display_options['pager']['options']['offset'] = '0';  
+  $handler->display->display_options['pager']['options']['offset'] = '0';
   $handler->display->display_options['defaults']['style_plugin'] = FALSE;
   $handler->display->display_options['style_plugin'] = 'table';
   $handler->display->display_options['style_options']['columns'] = array(
@@ -934,7 +1055,6 @@ function playbox_battles_views_default_views() {
   $handler->display->display_options['allow']['title_override'] = 0;
   $handler->display->display_options['allow']['exposed_form'] = 'exposed_form';
   $handler->display->display_options['allow']['fields_override'] = 'fields_override';
-  
   $export['playbox_battles'] = $view;
 
   return $export;


### PR DESCRIPTION
I modified the playbox_battles view, "List of completed battles" display and added it to the panel on the battles page. I figured I'd at least start by sharing the recreated feature. I'm also investigating a template override to modify this "List of completed battles" display. Hopefully this is a step in the right direction. This site has been pretty fun to learn with.